### PR TITLE
Adapting identify event to get other properties

### DIFF
--- a/Segment/Segment.php
+++ b/Segment/Segment.php
@@ -47,17 +47,14 @@ class Segment
      * Tags traits about the user.
      *
      * @param  int   $userId
-     * @param  array $traits
+     * @param  array $message
      * @return bool Whether the identify call succeeded
      */
-    public function identify($userId, array $traits)
+    public function identify($userId, array $message)
     {
-        return $this->getClient()->identify(
-            array(
-                'userId' => $userId,
-                'traits' => $traits,
-            )
-        );
+        $message['userId'] = $userId;
+
+        return $this->getClient()->identify($message);
     }
 
     /**

--- a/Tests/Segment/SegmentTest.php
+++ b/Tests/Segment/SegmentTest.php
@@ -19,6 +19,34 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test identify
+     */
+    public function testIdentify()
+    {
+        $userId = 90000;
+
+        $response = $this->segment->identify(
+            $userId,
+            array(
+                "traits" =>
+                    array(
+                        "name" => "Paul McCartney",
+                        "email" => "paul@test.com",
+                        "profession" => "solicitor",
+                    ),
+                "integrations" =>
+                    array(
+                        "Intercom" => array(
+                            "user_hash" => 'something'
+                        )
+                    )
+            ));
+
+        $this->assertTrue($response);
+    }
+
+
+    /**
      * Test track
      */
     public function testTrack()
@@ -27,25 +55,7 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
             2,
             'Test Event',
             array('property1' => 'Value 1',
-                  'property2' => 'Value 2',
-            )
-        );
-
-        $this->assertTrue($response);
-    }
-
-    /**
-     * Test identify
-     */
-    public function testIdentify()
-    {
-        $response = $this->segment->identify(
-            2,
-            array(
-                'traits' => array(
-                    'name' => 'John Lennon',
-                    'email' => 'john.lennon@test.com',
-                ),
+                'property2' => 'Value 2',
             )
         );
 
@@ -148,9 +158,12 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
 
         $segment->identify(
             'Calvin',
-            array('loves_php' => false,
-                'type' => 'analytics.log',
-                'birthday' => time()
+            array('traits' =>
+                array(
+                    'loves_php' => false,
+                    'type' => 'analytics.log',
+                    'birthday' => time()
+                ),
             )
         );
         $this->assertEquals(2, $socket->getQueueSize());
@@ -186,9 +199,12 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
 
         $response = $segment->identify(
             'Calvin',
-            array('loves_php' => false,
-                'type' => 'analytics.log',
-                'birthday' => time()
+            array('traits' =>
+                array(
+                    'loves_php' => false,
+                    'type' => 'analytics.log',
+                    'birthday' => time()
+                )
             )
         );
         $this->assertTrue($response);


### PR DESCRIPTION
Making method identify more flexible to receive a set of parameters (```$message```) instead of only "traits". This is useful for adding secure mode for Intercom on section "integrations".

```$message``` example:

```php
$message = array(
               "traits" =>
                   array(
                      "name" => "Paul McCartney",
                       "email" => "paul@test.com",
                       "profession" => "solicitor",
                   ),
               "integrations" =>
                   array(
                       "Intercom" => array(
                           "user_hash" => 'something'
                       )
                   )
           );
```